### PR TITLE
[MM-26589] Add context version to all public methods

### DIFF
--- a/circleci_test.go
+++ b/circleci_test.go
@@ -442,11 +442,11 @@ func TestClient_recentBuilds_multiPage(t *testing.T) {
 		case 0:
 			testQueryIncludes(t, r, "offset", "0")
 			testQueryIncludes(t, r, "limit", "100")
-			fmt.Fprint(w, fmt.Sprintf("[%s]", strings.Trim(strings.Repeat(`{"build_num": 123},`, 100), ",")))
+			fmt.Fprintf(w, "[%s]", strings.Trim(strings.Repeat(`{"build_num": 123},`, 100), ","))
 		case 1:
 			testQueryIncludes(t, r, "offset", "100")
 			testQueryIncludes(t, r, "limit", "99")
-			fmt.Fprint(w, fmt.Sprintf("[%s]", strings.Trim(strings.Repeat(`{"build_num": 123},`, 99), ",")))
+			fmt.Fprintf(w, "[%s]", strings.Trim(strings.Repeat(`{"build_num": 123},`, 99), ","))
 		default:
 			t.Errorf("Client.ListRecentBuilds(%+v, %+v) made more than two requests to /recent-builds", 199, 0)
 		}
@@ -471,7 +471,7 @@ func TestClient_recentBuilds_multiPageExhausted(t *testing.T) {
 		testMethod(t, r, "GET")
 		testQueryIncludes(t, r, "offset", "0")
 		testQueryIncludes(t, r, "limit", "100")
-		fmt.Fprint(w, fmt.Sprintf("[%s]", strings.Trim(strings.Repeat(`{"build_num": 123},`, 50), ",")))
+		fmt.Fprintf(w, "[%s]", strings.Trim(strings.Repeat(`{"build_num": 123},`, 50), ","))
 	})
 
 	builds, err := client.recentBuilds(context.Background(), "recent-builds", nil, 199, 0)
@@ -496,11 +496,11 @@ func TestClient_recentBuilds_multiPageNoLimit(t *testing.T) {
 		case 0:
 			testQueryIncludes(t, r, "offset", "0")
 			testQueryIncludes(t, r, "limit", "100")
-			fmt.Fprint(w, fmt.Sprintf("[%s]", strings.Trim(strings.Repeat(`{"build_num": 123},`, 100), ",")))
+			fmt.Fprintf(w, "[%s]", strings.Trim(strings.Repeat(`{"build_num": 123},`, 100), ","))
 		case 1:
 			testQueryIncludes(t, r, "offset", "100")
 			testQueryIncludes(t, r, "limit", "100")
-			fmt.Fprint(w, fmt.Sprintf("[%s]", strings.Trim(strings.Repeat(`{"build_num": 123},`, 99), ",")))
+			fmt.Fprintf(w, "[%s]", strings.Trim(strings.Repeat(`{"build_num": 123},`, 99), ","))
 		default:
 			t.Errorf("Client.ListRecentBuilds(%+v, %+v) made more than two requests to /recent-builds", -1, 0)
 		}
@@ -549,7 +549,7 @@ func TestClient_ListRecentBuildsForProject(t *testing.T) {
 		fmt.Fprint(w, `[{"build_num": 123}, {"build_num": 124}]`)
 	})
 
-	call := fmt.Sprintf("Client.ListRecentBuilds(foo, bar, master, running, 10, 0)")
+	call := "Client.ListRecentBuilds(foo, bar, master, running, 10, 0)"
 
 	builds, err := client.ListRecentBuildsForProject(VcsTypeGithub, "foo", "bar", "master", "running", 10, 0)
 	if err != nil {
@@ -573,7 +573,7 @@ func TestClient_ListRecentBuildsForProject_noBranch(t *testing.T) {
 		fmt.Fprint(w, `[{"build_num": 123}, {"build_num": 124}]`)
 	})
 
-	call := fmt.Sprintf("Client.ListRecentBuilds(foo, bar, , running, 10, 0)")
+	call := "Client.ListRecentBuilds(foo, bar, , running, 10, 0)"
 
 	builds, err := client.ListRecentBuildsForProject(VcsTypeGithub, "foo", "bar", "", "running", 10, 0)
 	if err != nil {

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -3,6 +3,7 @@ package circleci
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -117,11 +118,11 @@ func TestClientWithContext_request(t *testing.T) {
 		time.Sleep(1 * time.Second)
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 0*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Microsecond)
 	defer cancel()
 	err := client.request(ctx, "GET", "/me", &User{}, nil, nil)
-	if !strings.Contains(err.Error(), "context deadline exceeded") {
-		t.Errorf(`Client.request("GET", "/me", &User{}, nil, nil) didn't cancel request on timeout`)
+	if err == nil || !errors.As(err, &context.DeadlineExceeded) {
+		t.Error(`Client.request("GET", "/me", &User{}, nil, nil) didn't cancel request on timeout`)
 	}
 }
 
@@ -999,7 +1000,7 @@ func TestClient_GetActionOutput_withContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Microsecond)
 	defer cancel()
 	_, err := client.GetActionOutputsWithContext(ctx, action)
-	if err == nil || !strings.Contains(err.Error(), "context deadline exceeded") {
+	if err == nil || !errors.As(err, &context.DeadlineExceeded) {
 		t.Errorf("Client.GetActionOutput(%+v) should've returned context deadline error", action)
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

To be able to cancel the request by timeout or deadline we need to pass the context to the request.
    
This PR a new *WithContext method to all the exposed methods so the user can:

- Use the current method, which is going to create a [context.Background](https://golang.org/pkg/context/#Background) context
- Use the *WithContext method and pass their own context


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-26589
