### PR TITLE
Include all the missing VcsType in the project endpoints

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -219,14 +219,14 @@ func (c *Client) ListProjectsWithContext(ctx context.Context) ([]*Project, error
 
 // EnableProject enables a project - generates a deploy SSH key used to checkout the Github repo.
 // The Github user tied to the Circle API Token must have "admin" access to the repo.
-func (c *Client) EnableProject(account, repo string) error {
-	return c.EnableProjectWithContext(context.Background(), account, repo)
+func (c *Client) EnableProject(vcsType VcsType, account, repo string) error {
+	return c.EnableProjectWithContext(context.Background(), vcsType, account, repo)
 }
 
 // EnableProjectWithContext is the same as EnableProject with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) EnableProjectWithContext(ctx context.Context, account, repo string) error {
-	return c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/enable", account, repo), nil, nil, nil)
+func (c *Client) EnableProjectWithContext(ctx context.Context, vcsType VcsType, account, repo string) error {
+	return c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%s/enable", vcsType, account, repo), nil, nil, nil)
 }
 
 // DisableProject disables a project
@@ -241,16 +241,16 @@ func (c *Client) DisableProjectWithContext(ctx context.Context, account, repo st
 }
 
 // FollowProject follows a project
-func (c *Client) FollowProject(account, repo string) (*Project, error) {
-	return c.FollowProjectWithContext(context.Background(), account, repo)
+func (c *Client) FollowProject(vcsType VcsType, account, repo string) (*Project, error) {
+	return c.FollowProjectWithContext(context.Background(), vcsType, account, repo)
 }
 
 // FollowProjectWithContext is the same as FollowProject with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) FollowProjectWithContext(ctx context.Context, account, repo string) (*Project, error) {
+func (c *Client) FollowProjectWithContext(ctx context.Context, vcsType VcsType, account, repo string) (*Project, error) {
 	project := &Project{}
 
-	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/follow", account, repo), project, nil, nil)
+	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%s/follow", vcsType, account, repo), project, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -382,16 +382,16 @@ func (c *Client) ListRecentBuildsForProjectWithContext(ctx context.Context, vcsT
 }
 
 // GetBuild fetches a given build by number
-func (c *Client) GetBuild(account, repo string, buildNum int) (*Build, error) {
-	return c.GetBuildWithContext(context.Background(), account, repo, buildNum)
+func (c *Client) GetBuild(vcsType VcsType, account, repo string, buildNum int) (*Build, error) {
+	return c.GetBuildWithContext(context.Background(), vcsType, account, repo, buildNum)
 }
 
 // GetBuildWithContext is the same as GetBuild with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) GetBuildWithContext(ctx context.Context, account, repo string, buildNum int) (*Build, error) {
+func (c *Client) GetBuildWithContext(ctx context.Context, vcsType VcsType, account, repo string, buildNum int) (*Build, error) {
 	build := &Build{}
 
-	err := c.request(ctx, "GET", fmt.Sprintf("project/%s/%s/%d", account, repo, buildNum), build, nil, nil)
+	err := c.request(ctx, "GET", fmt.Sprintf("project/%s/%s/%s/%d", vcsType, account, repo, buildNum), build, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -418,18 +418,18 @@ func (c *Client) ListBuildArtifactsWithContext(ctx context.Context, vcsType VcsT
 }
 
 // ListTestMetadata fetches the build metadata for the given build
-func (c *Client) ListTestMetadata(account, repo string, buildNum int) ([]*TestMetadata, error) {
-	return c.ListTestMetadataWithContext(context.Background(), account, repo, buildNum)
+func (c *Client) ListTestMetadata(vcsType VcsType, account, repo string, buildNum int) ([]*TestMetadata, error) {
+	return c.ListTestMetadataWithContext(context.Background(), vcsType, account, repo, buildNum)
 }
 
 // ListTestMetadataWithContext is the same as ListTestMetadata with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) ListTestMetadataWithContext(ctx context.Context, account, repo string, buildNum int) ([]*TestMetadata, error) {
+func (c *Client) ListTestMetadataWithContext(ctx context.Context, vcsType VcsType, account, repo string, buildNum int) ([]*TestMetadata, error) {
 	metadata := struct {
 		Tests []*TestMetadata `json:"tests"`
 	}{}
 
-	err := c.request(ctx, "GET", fmt.Sprintf("project/%s/%s/%d/tests", account, repo, buildNum), &metadata, nil, nil)
+	err := c.request(ctx, "GET", fmt.Sprintf("project/%s/%s/%s/%d/tests", vcsType, account, repo, buildNum), &metadata, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -461,45 +461,45 @@ func (c *Client) AddSSHUserWithContext(ctx context.Context, account, repo string
 // Build triggers a new build for the given project for the given
 // project on the given branch.
 // Returns the new build information
-func (c *Client) Build(account, repo, branch string) (*Build, error) {
-	return c.BuildWithContext(context.Background(), account, repo, branch)
+func (c *Client) Build(vcsType VcsType, account, repo, branch string) (*Build, error) {
+	return c.BuildWithContext(context.Background(), vcsType, account, repo, branch)
 }
 
 // BuildWithContext is the same as Build with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) BuildWithContext(ctx context.Context, account, repo, branch string) (*Build, error) {
-	return c.BuildOptsWithContext(ctx, account, repo, branch, nil)
+func (c *Client) BuildWithContext(ctx context.Context, vcsType VcsType, account, repo, branch string) (*Build, error) {
+	return c.BuildOptsWithContext(ctx, vcsType, account, repo, branch, nil)
 }
 
 // ParameterizedBuild triggers a new parameterized build for the given
 // project on the given branch, Marshaling the struct into json and passing
 // in the post body.
 // Returns the new build information
-func (c *Client) ParameterizedBuild(account, repo, branch string, buildParameters map[string]string) (*Build, error) {
-	return c.ParameterizedBuildWithContext(context.Background(), account, repo, branch, buildParameters)
+func (c *Client) ParameterizedBuild(vcsType VcsType, account, repo, branch string, buildParameters map[string]string) (*Build, error) {
+	return c.ParameterizedBuildWithContext(context.Background(), vcsType, account, repo, branch, buildParameters)
 }
 
 // ParametrizedBuildWithContext is the same as ParametrizedBuild with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) ParameterizedBuildWithContext(ctx context.Context, account, repo, branch string, buildParameters map[string]string) (*Build, error) {
+func (c *Client) ParameterizedBuildWithContext(ctx context.Context, vcsType VcsType, account, repo, branch string, buildParameters map[string]string) (*Build, error) {
 	opts := map[string]interface{}{"build_parameters": buildParameters}
-	return c.BuildOptsWithContext(ctx, account, repo, branch, opts)
+	return c.BuildOptsWithContext(ctx, vcsType, account, repo, branch, opts)
 }
 
 // BuildOpts triggeres a new build for the givent project on the given
 // branch, Marshaling the struct into json and passing
 // in the post body.
 // Returns the new build information
-func (c *Client) BuildOpts(account, repo, branch string, opts map[string]interface{}) (*Build, error) {
-	return c.BuildOptsWithContext(context.Background(), account, repo, branch, opts)
+func (c *Client) BuildOpts(vcsType VcsType, account, repo, branch string, opts map[string]interface{}) (*Build, error) {
+	return c.BuildOptsWithContext(context.Background(), vcsType, account, repo, branch, opts)
 }
 
 // BuildOptsWithContext is the same as BuildOpts with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) BuildOptsWithContext(ctx context.Context, account, repo, branch string, opts map[string]interface{}) (*Build, error) {
+func (c *Client) BuildOptsWithContext(ctx context.Context, vcsType VcsType, account, repo, branch string, opts map[string]interface{}) (*Build, error) {
 	build := &Build{}
 
-	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/tree/%s", account, repo, branch), build, nil, opts)
+	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%s/tree/%s", vcsType, account, repo, branch), build, nil, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -596,16 +596,16 @@ func (c *Client) buildProject(ctx context.Context, vcsType VcsType, account stri
 
 // RetryBuild triggers a retry of the specified build
 // Returns the new build information
-func (c *Client) RetryBuild(account, repo string, buildNum int) (*Build, error) {
-	return c.RetryBuildWithContext(context.Background(), account, repo, buildNum)
+func (c *Client) RetryBuild(vcsType VcsType, account, repo string, buildNum int) (*Build, error) {
+	return c.RetryBuildWithContext(context.Background(), vcsType, account, repo, buildNum)
 }
 
 // RetryBuildWithContext is the same as RetryBuild with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) RetryBuildWithContext(ctx context.Context, account, repo string, buildNum int) (*Build, error) {
+func (c *Client) RetryBuildWithContext(ctx context.Context, vcsType VcsType, account, repo string, buildNum int) (*Build, error) {
 	build := &Build{}
 
-	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%d/retry", account, repo, buildNum), build, nil, nil)
+	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%s/%d/retry", vcsType, account, repo, buildNum), build, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -615,16 +615,16 @@ func (c *Client) RetryBuildWithContext(ctx context.Context, account, repo string
 
 // CancelBuild triggers a cancel of the specified build
 // Returns the new build information
-func (c *Client) CancelBuild(account, repo string, buildNum int) (*Build, error) {
-	return c.CancelBuildWithContext(context.Background(), account, repo, buildNum)
+func (c *Client) CancelBuild(vcsType VcsType, account, repo string, buildNum int) (*Build, error) {
+	return c.CancelBuildWithContext(context.Background(), vcsType, account, repo, buildNum)
 }
 
 // CancelBuildWithContext is the same as CancelBuild with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) CancelBuildWithContext(ctx context.Context, account, repo string, buildNum int) (*Build, error) {
+func (c *Client) CancelBuildWithContext(ctx context.Context, vcsType VcsType, account, repo string, buildNum int) (*Build, error) {
 	build := &Build{}
 
-	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%d/cancel", account, repo, buildNum), build, nil, nil)
+	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%s/%d/cancel", vcsType, account, repo, buildNum), build, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -634,18 +634,18 @@ func (c *Client) CancelBuildWithContext(ctx context.Context, account, repo strin
 
 // ClearCache clears the cache of the specified project
 // Returns the status returned by CircleCI
-func (c *Client) ClearCache(account, repo string) (string, error) {
-	return c.ClearCacheWithContext(context.Background(), account, repo)
+func (c *Client) ClearCache(vcsType VcsType, account, repo string) (string, error) {
+	return c.ClearCacheWithContext(context.Background(), vcsType, account, repo)
 }
 
 // ClearCacheWithContext is the same as ClearCache with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) ClearCacheWithContext(ctx context.Context, account, repo string) (string, error) {
+func (c *Client) ClearCacheWithContext(ctx context.Context, vcsType VcsType, account, repo string) (string, error) {
 	status := &struct {
 		Status string `json:"status"`
 	}{}
 
-	err := c.request(ctx, "DELETE", fmt.Sprintf("project/%s/%s/build-cache", account, repo), status, nil, nil)
+	err := c.request(ctx, "DELETE", fmt.Sprintf("project/%s/%s/%s/build-cache", vcsType, account, repo), status, nil, nil)
 	if err != nil {
 		return "", err
 	}
@@ -655,16 +655,16 @@ func (c *Client) ClearCacheWithContext(ctx context.Context, account, repo string
 
 // AddEnvVar adds a new environment variable to the specified project
 // Returns the added env var (the value will be masked)
-func (c *Client) AddEnvVar(account, repo, name, value string) (*EnvVar, error) {
-	return c.AddEnvVarWithContext(context.Background(), account, repo, name, value)
+func (c *Client) AddEnvVar(vcsType VcsType, account, repo, name, value string) (*EnvVar, error) {
+	return c.AddEnvVarWithContext(context.Background(), vcsType, account, repo, name, value)
 }
 
 // AddEnvVarWithContext is the same as AddEnvVar with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) AddEnvVarWithContext(ctx context.Context, account, repo, name, value string) (*EnvVar, error) {
+func (c *Client) AddEnvVarWithContext(ctx context.Context, vcsType VcsType, account, repo, name, value string) (*EnvVar, error) {
 	envVar := &EnvVar{}
 
-	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/envvar", account, repo), envVar, nil, &EnvVar{Name: name, Value: value})
+	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%s/envvar", vcsType, account, repo), envVar, nil, &EnvVar{Name: name, Value: value})
 	if err != nil {
 		return nil, err
 	}
@@ -674,16 +674,16 @@ func (c *Client) AddEnvVarWithContext(ctx context.Context, account, repo, name, 
 
 // ListEnvVars list environment variable to the specified project
 // Returns the env vars (the value will be masked)
-func (c *Client) ListEnvVars(account, repo string) ([]EnvVar, error) {
-	return c.ListEnvVarsWithContext(context.Background(), account, repo)
+func (c *Client) ListEnvVars(vcsType VcsType, account, repo string) ([]EnvVar, error) {
+	return c.ListEnvVarsWithContext(context.Background(), vcsType, account, repo)
 }
 
 // ListEnvVarsWithContext is the same as ListEnvVars with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) ListEnvVarsWithContext(ctx context.Context, account, repo string) ([]EnvVar, error) {
+func (c *Client) ListEnvVarsWithContext(ctx context.Context, vcsType VcsType, account, repo string) ([]EnvVar, error) {
 	envVar := []EnvVar{}
 
-	err := c.request(ctx, "GET", fmt.Sprintf("project/%s/%s/envvar", account, repo), &envVar, nil, nil)
+	err := c.request(ctx, "GET", fmt.Sprintf("project/%s/%s/%s/envvar", vcsType, account, repo), &envVar, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -692,29 +692,29 @@ func (c *Client) ListEnvVarsWithContext(ctx context.Context, account, repo strin
 }
 
 // DeleteEnvVar deletes the specified environment variable from the project
-func (c *Client) DeleteEnvVar(account, repo, name string) error {
-	return c.DeleteEnvVarWithContext(context.Background(), account, repo, name)
+func (c *Client) DeleteEnvVar(vcsType VcsType, account, repo, name string) error {
+	return c.DeleteEnvVarWithContext(context.Background(), vcsType, account, repo, name)
 }
 
 // DeleteEnvVarWithContext is the same as DeleteEnvVar with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) DeleteEnvVarWithContext(ctx context.Context, account, repo, name string) error {
-	return c.request(ctx, "DELETE", fmt.Sprintf("project/%s/%s/envvar/%s", account, repo, name), nil, nil, nil)
+func (c *Client) DeleteEnvVarWithContext(ctx context.Context, vcsType VcsType, account, repo, name string) error {
+	return c.request(ctx, "DELETE", fmt.Sprintf("project/%s/%s/%s/envvar/%s", vcsType, account, repo, name), nil, nil, nil)
 }
 
 // AddSSHKey adds a new SSH key to the project
-func (c *Client) AddSSHKey(account, repo, hostname, privateKey string) error {
-	return c.AddSSHKeyWithContext(context.Background(), account, repo, hostname, privateKey)
+func (c *Client) AddSSHKey(vcsType VcsType, account, repo, hostname, privateKey string) error {
+	return c.AddSSHKeyWithContext(context.Background(), vcsType, account, repo, hostname, privateKey)
 }
 
 // AddSSHKeyWithContext is the same as AddSSHKey with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) AddSSHKeyWithContext(ctx context.Context, account, repo, hostname, privateKey string) error {
+func (c *Client) AddSSHKeyWithContext(ctx context.Context, vcsType VcsType, account, repo, hostname, privateKey string) error {
 	key := &struct {
 		Hostname   string `json:"hostname"`
 		PrivateKey string `json:"private_key"`
 	}{hostname, privateKey}
-	return c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/ssh-key", account, repo), nil, nil, key)
+	return c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%s/ssh-key", vcsType, account, repo), nil, nil, key)
 }
 
 // GetActionOutputs fetches the output for the given action
@@ -775,20 +775,20 @@ func (c *Client) ListCheckoutKeysWithContext(ctx context.Context, account, repo 
 // Valid key types are currently deploy-key and github-user-key
 //
 // The github-user-key type requires that the API token being used be a user API token
-func (c *Client) CreateCheckoutKey(account, repo, keyType string) (*CheckoutKey, error) {
-	return c.CreateCheckoutKeyWithContext(context.Background(), account, repo, keyType)
+func (c *Client) CreateCheckoutKey(vcsType VcsType, account, repo, keyType string) (*CheckoutKey, error) {
+	return c.CreateCheckoutKeyWithContext(context.Background(), vcsType, account, repo, keyType)
 }
 
 // CreateCheckoutKeyWithContext is the same as CreateCheckoutKey with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) CreateCheckoutKeyWithContext(ctx context.Context, account, repo, keyType string) (*CheckoutKey, error) {
+func (c *Client) CreateCheckoutKeyWithContext(ctx context.Context, vcsType VcsType, account, repo, keyType string) (*CheckoutKey, error) {
 	checkoutKey := &CheckoutKey{}
 
 	body := struct {
 		KeyType string `json:"type"`
 	}{KeyType: keyType}
 
-	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/checkout-key", account, repo), checkoutKey, nil, body)
+	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%s/checkout-key", vcsType, account, repo), checkoutKey, nil, body)
 	if err != nil {
 		return nil, err
 	}
@@ -797,16 +797,16 @@ func (c *Client) CreateCheckoutKeyWithContext(ctx context.Context, account, repo
 }
 
 // GetCheckoutKey fetches the checkout key for the given project by fingerprint
-func (c *Client) GetCheckoutKey(account, repo, fingerprint string) (*CheckoutKey, error) {
-	return c.GetCheckoutKeyWithContext(context.Background(), account, repo, fingerprint)
+func (c *Client) GetCheckoutKey(vcsType VcsType, account, repo, fingerprint string) (*CheckoutKey, error) {
+	return c.GetCheckoutKeyWithContext(context.Background(), vcsType, account, repo, fingerprint)
 }
 
 // GetCheckoutKeyWithContext is the same as GetCheckoutKey with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) GetCheckoutKeyWithContext(ctx context.Context, account, repo, fingerprint string) (*CheckoutKey, error) {
+func (c *Client) GetCheckoutKeyWithContext(ctx context.Context, vcsType VcsType, account, repo, fingerprint string) (*CheckoutKey, error) {
 	checkoutKey := &CheckoutKey{}
 
-	err := c.request(ctx, "GET", fmt.Sprintf("project/%s/%s/checkout-key/%s", account, repo, fingerprint), &checkoutKey, nil, nil)
+	err := c.request(ctx, "GET", fmt.Sprintf("project/%s/%s/%s/checkout-key/%s", vcsType, account, repo, fingerprint), &checkoutKey, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -815,14 +815,14 @@ func (c *Client) GetCheckoutKeyWithContext(ctx context.Context, account, repo, f
 }
 
 // DeleteCheckoutKey fetches the checkout key for the given project by fingerprint
-func (c *Client) DeleteCheckoutKey(account, repo, fingerprint string) error {
-	return c.DeleteCheckoutKeyWithContext(context.Background(), account, repo, fingerprint)
+func (c *Client) DeleteCheckoutKey(vcsType VcsType, account, repo, fingerprint string) error {
+	return c.DeleteCheckoutKeyWithContext(context.Background(), vcsType, account, repo, fingerprint)
 }
 
 // GetCheckoutKeyWithContext is the same as GetCheckoutKey with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) DeleteCheckoutKeyWithContext(ctx context.Context, account, repo, fingerprint string) error {
-	return c.request(ctx, "DELETE", fmt.Sprintf("project/%s/%s/checkout-key/%s", account, repo, fingerprint), nil, nil, nil)
+func (c *Client) DeleteCheckoutKeyWithContext(ctx context.Context, vcsType VcsType, account, repo, fingerprint string) error {
+	return c.request(ctx, "DELETE", fmt.Sprintf("project/%s/%s/%s/checkout-key/%s", vcsType, account, repo, fingerprint), nil, nil, nil)
 }
 
 // AddHerokuKey associates a Heroku key with the user's API token to allow

--- a/circleci.go
+++ b/circleci.go
@@ -230,14 +230,14 @@ func (c *Client) EnableProjectWithContext(ctx context.Context, vcsType VcsType, 
 }
 
 // DisableProject disables a project
-func (c *Client) DisableProject(account, repo string) error {
-	return c.DisableProjectWithContext(context.Background(), account, repo)
+func (c *Client) DisableProject(vcsType VcsType, account, repo string) error {
+	return c.DisableProjectWithContext(context.Background(), vcsType, account, repo)
 }
 
 // DisableProjectWithContext is the same as DisableProject with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) DisableProjectWithContext(ctx context.Context, account, repo string) error {
-	return c.request(ctx, "DELETE", fmt.Sprintf("project/%s/%s/enable", account, repo), nil, nil, nil)
+func (c *Client) DisableProjectWithContext(ctx context.Context, vcsType VcsType, account, repo string) error {
+	return c.request(ctx, "DELETE", fmt.Sprintf("project/%s/%s/%s/enable", vcsType, account, repo), nil, nil, nil)
 }
 
 // FollowProject follows a project
@@ -263,16 +263,16 @@ func (c *Client) FollowProjectWithContext(ctx context.Context, vcsType VcsType, 
 }
 
 // UnfollowProject unfollows a project
-func (c *Client) UnfollowProject(account, repo string) (*Project, error) {
-	return c.UnfollowProjectWithContext(context.Background(), account, repo)
+func (c *Client) UnfollowProject(vcsType VcsType, account, repo string) (*Project, error) {
+	return c.UnfollowProjectWithContext(context.Background(), vcsType, account, repo)
 }
 
 // UnfollowProjectWithContext is the same as UnfollowProject with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) UnfollowProjectWithContext(ctx context.Context, account, repo string) (*Project, error) {
+func (c *Client) UnfollowProjectWithContext(ctx context.Context, vcsType VcsType, account, repo string) (*Project, error) {
 	project := &Project{}
 
-	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/unfollow", account, repo), project, nil, nil)
+	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%s/unfollow", vcsType, account, repo), project, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -441,16 +441,16 @@ func (c *Client) ListTestMetadataWithContext(ctx context.Context, vcsType VcsTyp
 // SSH users for a build.
 //
 // The API token being used must be a user API token
-func (c *Client) AddSSHUser(account, repo string, buildNum int) (*Build, error) {
-	return c.AddSSHUserWithContext(context.Background(), account, repo, buildNum)
+func (c *Client) AddSSHUser(vcsType VcsType, account, repo string, buildNum int) (*Build, error) {
+	return c.AddSSHUserWithContext(context.Background(), vcsType, account, repo, buildNum)
 }
 
 // AddSSHUserWithContext is the same as AddSSHUser with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) AddSSHUserWithContext(ctx context.Context, account, repo string, buildNum int) (*Build, error) {
+func (c *Client) AddSSHUserWithContext(ctx context.Context, vcsType VcsType, account, repo string, buildNum int) (*Build, error) {
 	build := &Build{}
 
-	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%d/ssh-users", account, repo, buildNum), build, nil, nil)
+	err := c.request(ctx, "POST", fmt.Sprintf("project/%s/%s/%s/%d/ssh-users", vcsType, account, repo, buildNum), build, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -754,16 +754,16 @@ func (c *Client) GetActionOutputsWithContext(ctx context.Context, a *Action) ([]
 }
 
 // ListCheckoutKeys fetches the checkout keys associated with the given project
-func (c *Client) ListCheckoutKeys(account, repo string) ([]*CheckoutKey, error) {
-	return c.ListCheckoutKeysWithContext(context.Background(), account, repo)
+func (c *Client) ListCheckoutKeys(vcsType VcsType, account, repo string) ([]*CheckoutKey, error) {
+	return c.ListCheckoutKeysWithContext(context.Background(), vcsType, account, repo)
 }
 
 // ListCheckoutKeysWithContext is the same as ListCheckoutKeys with the addition of the context
 // parameter that would be used to request cancellation.
-func (c *Client) ListCheckoutKeysWithContext(ctx context.Context, account, repo string) ([]*CheckoutKey, error) {
+func (c *Client) ListCheckoutKeysWithContext(ctx context.Context, vcsType VcsType, account, repo string) ([]*CheckoutKey, error) {
 	checkoutKeys := []*CheckoutKey{}
 
-	err := c.request(ctx, "GET", fmt.Sprintf("project/%s/%s/checkout-key", account, repo), &checkoutKeys, nil, nil)
+	err := c.request(ctx, "GET", fmt.Sprintf("project/%s/%s/%s/checkout-key", vcsType, account, repo), &checkoutKeys, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -305,11 +305,11 @@ func TestClient_ListProjects_parseNullableFeatureFlags(t *testing.T) {
 func TestClient_EnableProject(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/org-name/repo-name/enable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/org-name/repo-name/enable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
-	err := client.EnableProject("org-name", "repo-name")
+	err := client.EnableProject(VcsTypeGithub, "org-name", "repo-name")
 	if err != nil {
 		t.Errorf("Client.EnableProject() returned error: %v", err)
 	}
@@ -331,12 +331,12 @@ func TestClient_DisableProject(t *testing.T) {
 func TestClient_FollowProject(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/org-name/repo-name/follow", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/org-name/repo-name/follow", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"reponame": "repo-name"}`)
 	})
 
-	project, err := client.FollowProject("org-name", "repo-name")
+	project, err := client.FollowProject(VcsTypeGithub, "org-name", "repo-name")
 	if err != nil {
 		t.Errorf("Client.FollowProject() returned error: %v", err)
 	}
@@ -590,12 +590,12 @@ func TestClient_ListRecentBuildsForProject_noBranch(t *testing.T) {
 func TestClient_GetBuild(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/jszwedko/foo/123", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"build_num": 123}`)
 	})
 
-	build, err := client.GetBuild("jszwedko", "foo", 123)
+	build, err := client.GetBuild(VcsTypeGithub, "jszwedko", "foo", 123)
 	if err != nil {
 		t.Errorf("Client.GetBuild(jszwedko, foo, 123) returned error: %v", err)
 	}
@@ -628,12 +628,12 @@ func TestClient_ListBuildArtifacts(t *testing.T) {
 func TestClient_ListTestMetadata(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/jszwedko/foo/123/tests", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/123/tests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"tests": [{"name": "some test"}]}`)
 	})
 
-	metadata, err := client.ListTestMetadata("jszwedko", "foo", 123)
+	metadata, err := client.ListTestMetadata(VcsTypeGithub, "jszwedko", "foo", 123)
 	if err != nil {
 		t.Errorf("Client.ListTestMetadata(jszwedko, foo, 123) returned error: %v", err)
 	}
@@ -647,12 +647,12 @@ func TestClient_ListTestMetadata(t *testing.T) {
 func TestClient_Build(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/jszwedko/foo/tree/master", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/tree/master", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"build_num": 123}`)
 	})
 
-	build, err := client.Build("jszwedko", "foo", "master")
+	build, err := client.Build(VcsTypeGithub, "jszwedko", "foo", "master")
 	if err != nil {
 		t.Errorf("Client.Build(jszwedko, foo, master) returned error: %v", err)
 	}
@@ -667,7 +667,7 @@ func TestClient_ParameterizedBuild(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/project/jszwedko/foo/tree/master", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/tree/master", func(w http.ResponseWriter, r *http.Request) {
 		testBody(t, r, `{"build_parameters":{"param":"foo"}}`)
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"build_num": 123}`)
@@ -677,7 +677,7 @@ func TestClient_ParameterizedBuild(t *testing.T) {
 		"param": "foo",
 	}
 
-	build, err := client.ParameterizedBuild("jszwedko", "foo", "master", params)
+	build, err := client.ParameterizedBuild(VcsTypeGithub, "jszwedko", "foo", "master", params)
 	if err != nil {
 		t.Errorf("Client.Build(jszwedko, foo, master) returned error: %v", err)
 	}
@@ -692,7 +692,7 @@ func TestClient_BuildOpts(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/project/jszwedko/foo/tree/master", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/tree/master", func(w http.ResponseWriter, r *http.Request) {
 		testBody(t, r, `{"build_parameters":{"param":"foo"},"revision":"SHA"}`)
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"build_num": 123}`)
@@ -705,7 +705,7 @@ func TestClient_BuildOpts(t *testing.T) {
 		"revision": "SHA",
 	}
 
-	build, err := client.BuildOpts("jszwedko", "foo", "master", opts)
+	build, err := client.BuildOpts(VcsTypeGithub, "jszwedko", "foo", "master", opts)
 	if err != nil {
 		t.Errorf("Client.Build(jszwedko, foo, master) returned error: %v", err)
 	}
@@ -788,12 +788,12 @@ func TestClient_BuildByProject(t *testing.T) {
 func TestClient_RetryBuild(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/jszwedko/foo/123/retry", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/123/retry", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"build_num": 124}`)
 	})
 
-	build, err := client.RetryBuild("jszwedko", "foo", 123)
+	build, err := client.RetryBuild(VcsTypeGithub, "jszwedko", "foo", 123)
 	if err != nil {
 		t.Errorf("Client.RetryBuild(jszwedko, foo, 123) returned error: %v", err)
 	}
@@ -807,12 +807,12 @@ func TestClient_RetryBuild(t *testing.T) {
 func TestClient_CancelBuild(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/jszwedko/foo/123/cancel", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/123/cancel", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"build_num": 123}`)
 	})
 
-	build, err := client.CancelBuild("jszwedko", "foo", 123)
+	build, err := client.CancelBuild(VcsTypeGithub, "jszwedko", "foo", 123)
 	if err != nil {
 		t.Errorf("Client.CancelBuild(jszwedko, foo, 123) returned error: %v", err)
 	}
@@ -826,12 +826,12 @@ func TestClient_CancelBuild(t *testing.T) {
 func TestClient_ClearCache(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/jszwedko/foo/build-cache", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/build-cache", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		fmt.Fprint(w, `{"status": "cache cleared"}`)
 	})
 
-	status, err := client.ClearCache("jszwedko", "foo")
+	status, err := client.ClearCache(VcsTypeGithub, "jszwedko", "foo")
 	if err != nil {
 		t.Errorf("Client.ClearCache(jszwedko, foo) returned error: %v", err)
 	}
@@ -845,13 +845,13 @@ func TestClient_ClearCache(t *testing.T) {
 func TestClient_AddEnvVar(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/jszwedko/foo/envvar", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/envvar", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testBody(t, r, `{"name":"bar","value":"baz"}`)
 		fmt.Fprint(w, `{"name": "bar"}`)
 	})
 
-	status, err := client.AddEnvVar("jszwedko", "foo", "bar", "baz")
+	status, err := client.AddEnvVar(VcsTypeGithub, "jszwedko", "foo", "bar", "baz")
 	if err != nil {
 		t.Errorf("Client.AddEnvVar(jszwedko, foo, bar, baz) returned error: %v", err)
 	}
@@ -865,13 +865,13 @@ func TestClient_AddEnvVar(t *testing.T) {
 func TestClient_ListEnvVars(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/jszwedko/foo/envvar", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/envvar", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testBody(t, r, "")
 		fmt.Fprint(w, `[{"name": "bar", "value":"xxxbar"}]`)
 	})
 
-	status, err := client.ListEnvVars("jszwedko", "foo")
+	status, err := client.ListEnvVars(VcsTypeGithub, "jszwedko", "foo")
 	if err != nil {
 		t.Errorf("Client.ListEnvVars(jszwedko, foo) returned error: %v", err)
 	}
@@ -888,12 +888,12 @@ func TestClient_ListEnvVars(t *testing.T) {
 func TestClient_DeleteEnvVar(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/jszwedko/foo/envvar/bar", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/envvar/bar", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := client.DeleteEnvVar("jszwedko", "foo", "bar")
+	err := client.DeleteEnvVar(VcsTypeGithub, "jszwedko", "foo", "bar")
 	if err != nil {
 		t.Errorf("Client.DeleteEnvVar(jszwedko, foo, bar) returned error: %v", err)
 	}
@@ -902,13 +902,13 @@ func TestClient_DeleteEnvVar(t *testing.T) {
 func TestClient_AddSSHKey(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/jszwedko/foo/ssh-key", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/ssh-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testBody(t, r, `{"hostname":"example.com","private_key":"some-key"}`)
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	err := client.AddSSHKey("jszwedko", "foo", "example.com", "some-key")
+	err := client.AddSSHKey(VcsTypeGithub, "jszwedko", "foo", "example.com", "some-key")
 	if err != nil {
 		t.Errorf("Client.AddSSHKey(jszwedko, foo, example.com, some-key) returned error: %v", err)
 	}
@@ -1041,7 +1041,7 @@ func TestClient_CreateCheckoutKey(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/project/jszwedko/foo/checkout-key", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/checkout-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testBody(t, r, `{"type":"github-user-key"}`)
 		fmt.Fprintf(w, `{
@@ -1053,7 +1053,7 @@ func TestClient_CreateCheckoutKey(t *testing.T) {
 		}`)
 	})
 
-	checkoutKey, err := client.CreateCheckoutKey("jszwedko", "foo", "github-user-key")
+	checkoutKey, err := client.CreateCheckoutKey(VcsTypeGithub, "jszwedko", "foo", "github-user-key")
 	if err != nil {
 		t.Errorf("Client.CreateCheckoutKey(jszwedko, foo, github-user-key) returned error: %v", err)
 	}
@@ -1075,7 +1075,7 @@ func TestClient_GetCheckoutKey(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/project/jszwedko/foo/checkout-key/37:27:f7:68:85:43:46:d2:e1:30:83:8f:f7:1b:ad:c2", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/checkout-key/37:27:f7:68:85:43:46:d2:e1:30:83:8f:f7:1b:ad:c2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprintf(w, `{
 			"public_key": "some public key",
@@ -1086,7 +1086,7 @@ func TestClient_GetCheckoutKey(t *testing.T) {
 		}`)
 	})
 
-	checkoutKey, err := client.GetCheckoutKey("jszwedko", "foo", "37:27:f7:68:85:43:46:d2:e1:30:83:8f:f7:1b:ad:c2")
+	checkoutKey, err := client.GetCheckoutKey(VcsTypeGithub, "jszwedko", "foo", "37:27:f7:68:85:43:46:d2:e1:30:83:8f:f7:1b:ad:c2")
 	if err != nil {
 		t.Errorf("Client.GetCheckoutKey(jszwedko, foo, 37:27:f7:68:85:43:46:d2:e1:30:83:8f:f7:1b:ad:c2) returned error: %v", err)
 	}
@@ -1107,12 +1107,12 @@ func TestClient_DeleteCheckoutKey(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/project/jszwedko/foo/checkout-key/37:27:f7:68:85:43:46:d2:e1:30:83:8f:f7:1b:ad:c2", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/checkout-key/37:27:f7:68:85:43:46:d2:e1:30:83:8f:f7:1b:ad:c2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		fmt.Fprintf(w, `{"message": "ok"}`)
 	})
 
-	err := client.DeleteCheckoutKey("jszwedko", "foo", "37:27:f7:68:85:43:46:d2:e1:30:83:8f:f7:1b:ad:c2")
+	err := client.DeleteCheckoutKey(VcsTypeGithub, "jszwedko", "foo", "37:27:f7:68:85:43:46:d2:e1:30:83:8f:f7:1b:ad:c2")
 	if err != nil {
 		t.Errorf("Client.DeleteCheckoutKey(jszwedko, foo, 37:27:f7:68:85:43:46:d2:e1:30:83:8f:f7:1b:ad:c2) returned error: %v", err)
 	}

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -318,11 +318,11 @@ func TestClient_EnableProject(t *testing.T) {
 func TestClient_DisableProject(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/org-name/repo-name/enable", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/org-name/repo-name/enable", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
-	err := client.DisableProject("org-name", "repo-name")
+	err := client.DisableProject(VcsTypeGithub, "org-name", "repo-name")
 	if err != nil {
 		t.Errorf("Client.EnableProject() returned error: %v", err)
 	}
@@ -350,12 +350,12 @@ func TestClient_FollowProject(t *testing.T) {
 func TestClient_UnfollowProject(t *testing.T) {
 	setup()
 	defer teardown()
-	mux.HandleFunc("/project/org-name/repo-name/unfollow", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/org-name/repo-name/unfollow", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"reponame": "repo-name"}`)
 	})
 
-	project, err := client.UnfollowProject("org-name", "repo-name")
+	project, err := client.UnfollowProject(VcsTypeGithub, "org-name", "repo-name")
 	if err != nil {
 		t.Errorf("Client.UnfollowProject() returned error: %v", err)
 	}
@@ -1009,7 +1009,7 @@ func TestClient_ListCheckoutKeys(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/project/jszwedko/foo/checkout-key", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/checkout-key", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprintf(w, `[{
 			"public_key": "some public key",
@@ -1020,7 +1020,7 @@ func TestClient_ListCheckoutKeys(t *testing.T) {
 		}]`)
 	})
 
-	checkoutKeys, err := client.ListCheckoutKeys("jszwedko", "foo")
+	checkoutKeys, err := client.ListCheckoutKeys(VcsTypeGithub, "jszwedko", "foo")
 	if err != nil {
 		t.Errorf("Client.ListCheckoutKeys(jszwedko, foo) returned error: %v", err)
 	}
@@ -1122,12 +1122,12 @@ func TestClient_AddSSHUser(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/project/jszwedko/foo/123/ssh-users", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/project/github/jszwedko/foo/123/ssh-users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{"ssh_users": [{"github_id": 1234, "login": "jszwedko"}]}`)
 	})
 
-	build, err := client.AddSSHUser("jszwedko", "foo", 123)
+	build, err := client.AddSSHUser(VcsTypeGithub, "jszwedko", "foo", 123)
 	if err != nil {
 		t.Errorf("Client.AddSSHUser(jszwedko, foo, 123) returned error: %v", err)
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

CircleCI API 1.1 [requires](https://circleci.com/docs/api/#version-control-systems-vcs-type) the `:vcs-type` in most of the `projects` endpoints. We have adapted only 2 of them and this PR fixes the rest of endpoints

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-26589