### PR TITLE
Fix trigger pipeline

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -1017,8 +1017,8 @@ func (c *Client) TriggerPipelineWithContext(ctx context.Context, vcsType VcsType
 	}
 	p := &Pipeline{}
 	body := struct {
-		Branch     string                 `json:"branch"`
-		Tag        string                 `json:"tag"`
+		Branch     string                 `json:"branch,omitempty"`
+		Tag        string                 `json:"tag,omitempty"`
 		Parameters map[string]interface{} `json:"parameters"`
 	}{
 		Branch:     branch,

--- a/circleci.go
+++ b/circleci.go
@@ -1008,8 +1008,8 @@ func (c *Client) TriggerPipeline(vcsType VcsType, account, repo, branch, tag str
 }
 
 // TriggerPipeline triggers a new pipeline for the given project for the given branch or tag.
-// Note that branch and tag are mutually exclusive. It is not exactly specified in the documentation
-// which takes precendence when both are specified.
+// Note that branch and tag are mutually exclusive and if both are sent circleci will return
+// a 400 error
 // https://circleci.com/docs/api/v2/?shell#trigger-a-new-pipeline
 // Note that this is only available as a v2 API.
 func (c *Client) TriggerPipelineWithContext(ctx context.Context, vcsType VcsType, account, repo, branch, tag string, params map[string]interface{}) (*Pipeline, error) {

--- a/circleci.go
+++ b/circleci.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1015,6 +1016,11 @@ func (c *Client) TriggerPipelineWithContext(ctx context.Context, vcsType VcsType
 	if c.Version < APIVersion2 {
 		return nil, newInvalidVersionError(c.Version)
 	}
+
+	if branch != "" && tag != "" {
+		return nil, errors.New("branch and tag parameters are mutually exclusive. Please send just one")
+	}
+
 	p := &Pipeline{}
 	body := struct {
 		Branch     string                 `json:"branch,omitempty"`

--- a/circleci.go
+++ b/circleci.go
@@ -1009,7 +1009,7 @@ func (c *Client) TriggerPipeline(vcsType VcsType, account, repo, branch, tag str
 
 // TriggerPipeline triggers a new pipeline for the given project for the given branch or tag.
 // Note that branch and tag are mutually exclusive and if both are sent circleci will return
-// a 400 error
+// an error
 // https://circleci.com/docs/api/v2/?shell#trigger-a-new-pipeline
 // Note that this is only available as a v2 API.
 func (c *Client) TriggerPipelineWithContext(ctx context.Context, vcsType VcsType, account, repo, branch, tag string, params map[string]interface{}) (*Pipeline, error) {

--- a/circleci_test.go
+++ b/circleci_test.go
@@ -1160,7 +1160,7 @@ func TestClient_TriggerPipeline(t *testing.T) {
 
 	mux.HandleFunc("/project/github/mattermost/mattermod/pipeline", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testBody(t, r, `{"branch":"testbranch","tag":"","parameters":{"tbs_pr":"bar","tbs_sha":"foo"}}`)
+		testBody(t, r, `{"branch":"testbranch","parameters":{"tbs_pr":"bar","tbs_sha":"foo"}}`)
 		fmt.Fprint(w, `{"id": "foo", "state": "running", "number": 1, "created_at": "2020-08-05T19:33:08Z"}`)
 	})
 	client.Version = APIVersion2


### PR DESCRIPTION
We're facing an error that looks like comes from our call to circleci: ` 400: Invalid input`

My best guess is that we're sending both parameters branch and tag and in old code, we're just sending the branch so given that both are mutually exclusive, according to the documentation, I've changed the code to avoid send the parameter if it's empty

